### PR TITLE
Add setting for fade animation.

### DIFF
--- a/darknewtab.html
+++ b/darknewtab.html
@@ -1,5 +1,5 @@
 <html>
-<title>Dark New Tab</title>
+<title>New Tab</title>
 <style>
 	@keyframes turnUpBrightness {
 		from {background-color:hsla(0, 0%, 0%, 1)}
@@ -7,10 +7,9 @@
 	}
 	body {
 		background-color:hsla(0, 0%, 20%, 1);
-		animation-name: turnUpBrightness;
-		animation-duration: 3s;
 	}
 </style>
 <body>
+<script type="text/javascript" src="darknewtab.js"></script>
 </body>
 </html>

--- a/darknewtab.js
+++ b/darknewtab.js
@@ -1,0 +1,6 @@
+chrome.storage.sync.get({ fadeSetting: true }, ({ fadeSetting }) => {
+  if (fadeSetting) {
+    // If the fade setting is enabled (default), apply animation to body.
+    document.body.style = "animation-name: turnUpBrightness; animation-duration: 3s;"
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,8 @@
   "version": "1.2",
   "incognito": "split",
   "chrome_url_overrides": { "newtab": "darknewtab.html" },
+  "options_ui": { "page": "options.html", "open_in_tab": false },
+  "permissions": ["storage"],
   "manifest_version": 2,
   "author": "Daniel W. Lu",
   "homepage_url": "https://github.com/dandydanny/darknewtab"

--- a/options.html
+++ b/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Dark New Tab Options</title>
+  <style>
+    #status {
+      color: #008000;
+    }
+  </style>
+</head>
+
+<body>
+  <label><input type="checkbox" id="fade"> Enable fade-in animation</label>
+
+  <p id="status"></p>
+
+  <button id="save">Save</button>
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,18 @@
+const fadeCheckbox = document.getElementById('fade');
+const saveButton = document.getElementById('save');
+const status = document.getElementById('status');
+
+// Display current preference when returning to options:
+document.addEventListener('DOMContentLoaded', event => {
+  chrome.storage.sync.get({ fadeSetting: true }, ({ fadeSetting }) => {
+    fadeCheckbox.checked = fadeSetting;
+  });
+});
+
+// Save preference to chrome.storage when hitting 'Save':
+saveButton.addEventListener('click', event => {
+  chrome.storage.sync.set({ fadeSetting: fadeCheckbox.checked }, () => {
+    status.textContent = 'Your preference has been saved.';
+    setTimeout(() => status.textContent = '', 2000);
+  });
+});


### PR DESCRIPTION
Thanks for this extension! 💯 I wanted to be able to disable the "fade-in" animation, and so I added a dead-simple options panel with that as a checkbox (still enabled by default):

![](https://user-images.githubusercontent.com/583202/54331793-f1f04100-45f1-11e9-8d00-e1bb524a3b3a.gif)

