### PR TITLE
Fixes #11.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "version": "1.3",
   "incognito": "split",
   "chrome_url_overrides": { "newtab": "darknewtab.html" },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "author": "Daniel W. Lu",
   "homepage_url": "https://github.com/dandydanny/darknewtab"
 }


### PR DESCRIPTION
According to the [migration
guide](https://developer.chrome.com/docs/extensions/develop/migrate) we should be able to increment the version as a first step; looking at the [current
docs](https://developer.chrome.com/docs/extensions/develop/ui/override-chrome-pages) the newtab override is still supported.